### PR TITLE
fix-compilation-errors-in-alpine-11

### DIFF
--- a/ouster_ros/CMakeLists.txt
+++ b/ouster_ros/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(
 
 # ==== Options ====
 set(CMAKE_CXX_STANDARD 14)
-add_compile_options(-Wall -Wextra -Werror)
+add_compile_options(-Wall -Wextra)
 option(CMAKE_POSITION_INDEPENDENT_CODE "Build position independent code." ON)
 
 # ==== Catkin ====
@@ -61,7 +61,7 @@ add_subdirectory(./ouster_client ouster_client EXCLUDE_FROM_ALL)
 set(BUILD_SHARED_LIBS ${_SAVE_BUILD_SHARED_LIBS})
 
 # catkin adds all include dirs to a single variable, don't try to use targets
-include_directories(${_ouster_ros_INCLUDE_DIRS} SYSTEM ${catkin_INCLUDE_DIRS})
+include_directories(${_ouster_ros_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 add_library(ouster_ros src/ros.cpp)
 target_link_libraries(ouster_ros PUBLIC ${catkin_LIBRARIES} ouster_build PRIVATE


### PR DESCRIPTION
This PR fixes the following errors:
- Error due to `SYSTEM`:
```
In file included from /usr/include/c++/9.3.0/ext/string_conversions.h:41,
                 from /usr/include/c++/9.3.0/bits/basic_string.h:6493,
                 from /usr/include/c++/9.3.0/string:55,
                 from /usr/ros/noetic/include/geometry_msgs/TransformStamped.h:9,
                 from /ws/src/ouster_example/ouster_ros/include/ouster_ros/ros.h:9,
                 from /ws/src/ouster_example/ouster_ros/src/ros.cpp:1:
/usr/include/c++/9.3.0/cstdlib:75:15: fatal error: stdlib.h: No such file or directory
   75 | #include_next <stdlib.h>
      |               ^~~~~~~~~~
compilation terminated.
```

- Error due to `-Werror`:
```
In file included from /usr/include/pcl-1.10/pcl/io/low_level_io.h:61,
                 from /usr/include/pcl-1.10/pcl/io/impl/pcd_io.hpp:49,
                 from /usr/include/pcl-1.10/pcl/io/pcd_io.h:788,
                 from /usr/ros/noetic/include/pcl_conversions/pcl_conversions.h:70,
                 from /ws/src/ouster_example/ouster_ros/src/ros.cpp:3:
/usr/include/sys/fcntl.h:1:2: error: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Werror=cpp]
    1 | #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
      |  ^~~~~~~
cc1plus: all warnings being treated as errors

```